### PR TITLE
iOS double tap fix

### DIFF
--- a/css/ui-accordion.css
+++ b/css/ui-accordion.css
@@ -15,9 +15,10 @@
     .accordion-wrapper label:hover {
       background: #eee;
       color: #444; }
+  .accordion-wrapper label:after, .accordion-wrapper input:checked + label:after {
+    content: ''; }
   .accordion-wrapper label:hover:after, .accordion-wrapper input:checked + label:hover:after {
     opacity: 0.3;
-    content: '';
     position: absolute;
     width: 30px;
     height: 20px;

--- a/scss/ui-accordion.scss
+++ b/scss/ui-accordion.scss
@@ -20,9 +20,12 @@
     }
   }
 
+  label:after, input:checked + label:after {
+    content: '';
+  }
+
   label:hover:after, input:checked + label:hover:after {
     opacity: 0.3;
-    content: '';
     position: absolute;
     width: 30px;
     height: 20px;


### PR DESCRIPTION
Make :after elements always display for labels (not just on hover) so they'll be displayed on first click on iOS.

Reference: https://css-tricks.com/annoying-mobile-double-tap-link-issue/