### PR TITLE
Fix image compare shortcode not doing anything

### DIFF
--- a/classes/shortcodes/ImageCompareShortcode.php
+++ b/classes/shortcodes/ImageCompareShortcode.php
@@ -15,7 +15,7 @@ class ImageCompareShortcode extends Shortcode
 
             $content = $sc->getContent();
 
-            preg_match_all('/<img.*(?:alt="(.*?)").*\/>/', $content, $matches);
+            preg_match_all('/<img.*(?:alt="(.*?)").*\/?>/', $content, $matches);
 
             if (count($matches) === 2 && count($matches[0]) === 2) {
                 return $this->twig->processTemplate(


### PR DESCRIPTION
I had the same problem as in [this issue](https://github.com/getgrav/grav-plugin-shortcode-ui/issues/33).

I was able to track it down, apparently the regex in ImageCompareShortcode.php only allowed <img .../> not <img ...> tags (without the ending slash).